### PR TITLE
db Overhaul and Push method filled out

### DIFF
--- a/.calva/output-window/output.calva-repl
+++ b/.calva/output-window/output.calva-repl
@@ -1,0 +1,828 @@
+; This is the Calva evaluation results output window.
+; TIPS: The keyboard shortcut `ctrl+alt+c o` shows and focuses this window
+;   when connected to a REPL session.
+; Please see https://calva.io/output/ for more info.
+; Happy coding! ♥️
+
+; Jacking in...
+; Starting Jack-in Terminal: cmd.exe /d /c lein update-in :dependencies conj [nrepl,"0.8.3"] -- update-in :plugins conj [cider/cider-nrepl,"0.26.0"] -- update-in [:repl-options,:nrepl-middleware] conj '["cider.nrepl/cider-middleware"]' -- repl :headless
+; nREPL Connection was closed
+; Hooking up nREPL sessions...
+; Connected session: clj
+; TIPS: 
+;   - You can edit the contents here. Use it as a REPL if you like.
+;   - `alt+enter` evaluates the current top level form.
+;   - `ctrl+enter` evaluates the current form.
+;   - `alt+up` and `alt+down` traverse up and down the REPL command history
+;      when the cursor is after the last contents at the prompt
+;   - Clojure lines in stack traces are peekable and clickable.
+clj꞉s71-challenge.core꞉> 
+; Jack-in done.
+clj꞉s71-challenge.core꞉> 
+; Evaluating file: actions.clj
+; WARNING: peek already refers to: #'clojure.core/peek in namespace: s71-challenge.queue.actions, being replaced by: #'s71-challenge.queue.actions/peek
+tests
+6
+; WARNING: pop already refers to: #'clojure.core/pop in namespace: s71-challenge.queue.actions, being replaced by: #'s71-challenge.queue.actions/pop
+#'s71-challenge.queue.actions/queue-length
+clj꞉s71-challenge.queue.actions꞉> 
+()
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 1, :message "Message 77", :status "hidden", :created_at #inst "2021-07-02T19:51:49.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+()
+clj꞉s71-challenge.queue.actions꞉> 
+1
+clj꞉s71-challenge.queue.actions꞉> 
+()
+clj꞉s71-challenge.queue.actions꞉> 
+()
+clj꞉s71-challenge.queue.actions꞉> 
+{:generated_key 2}
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 2, :message "Message 77", :status "pending", :created_at #inst "2021-07-02T19:52:35.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 2, :message "Message 77", :status "pending", :created_at #inst "2021-07-02T19:52:35.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+1
+clj꞉s71-challenge.queue.actions꞉> 
+{:generated_key 3}
+clj꞉s71-challenge.queue.actions꞉> 
+{:generated_key 4}
+clj꞉s71-challenge.queue.actions꞉> 
+{:generated_key 5}
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 3, :message "Message 74", :status "pending", :created_at #inst "2021-07-02T19:53:20.000000000-00:00"} {:id 4, :message "Message 76", :status "pending", :created_at #inst "2021-07-02T19:53:23.000000000-00:00"} {:id 5, :message "Message 7", :status "pending", :created_at #inst "2021-07-02T19:53:25.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+{:status "hidden", :id 4}
+clj꞉s71-challenge.queue.actions꞉> 
+1
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 2, :message "Message 77", :status "hidden", :created_at #inst "2021-07-02T19:52:35.000000000-00:00"} {:id 3, :message "Message 74", :status "pending", :created_at #inst "2021-07-02T19:53:20.000000000-00:00"} {:id 4, :message "Message 76", :status "hidden", :created_at #inst "2021-07-02T19:53:23.000000000-00:00"} {:id 5, :message "Message 7", :status "pending", :created_at #inst "2021-07-02T19:53:25.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 3, :message "Message 74", :status "pending", :created_at #inst "2021-07-02T19:53:20.000000000-00:00"} {:id 5, :message "Message 7", :status "pending", :created_at #inst "2021-07-02T19:53:25.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+{:id 3, :message "Message 74", :status "pending", :created_at #inst "2021-07-02T19:53:20.000000000-00:00"}
+clj꞉s71-challenge.queue.actions꞉> 
+3
+clj꞉s71-challenge.queue.actions꞉> 
+2
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/push
+clj꞉s71-challenge.queue.actions꞉> 
+; Error printing return value (ExceptionInfo) at hugsql.core/validate-parameters! (core.clj:83).
+; Parameter Mismatch: :message parameter data not found.
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/push
+clj꞉s71-challenge.queue.actions꞉> 
+({:generated_key 6} {:generated_key 7} {:generated_key 8} {:generated_key 9} {:generated_key 10})
+clj꞉s71-challenge.queue.actions꞉> 
+{:generated_key 11}
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 3, :message "Message 74", :status "pending", :created_at #inst "2021-07-02T19:53:20.000000000-00:00"} {:id 5, :message "Message 7", :status "pending", :created_at #inst "2021-07-02T19:53:25.000000000-00:00"} {:id 6, :message "1", :status "pending", :created_at #inst "2021-07-02T19:59:51.000000000-00:00"} {:id 7, :message "2", :status "pending", :created_at #inst "2021-07-02T19:59:52.000000000-00:00"} {:id 8, :message "3", :status "pending", :created_at #inst "2021-07-02T19:59:53.000000000-00:00"} {:id 9, :message "4", :status "pending", :created_at #inst "2021-07-02T19:59:53.000000000-00:00"} {:id 10, :message "5", :status "pending", :created_at #inst "2021-07-02T19:59:54.000000000-00:00"} {:id 11, :message "Message 7", :status "pending", :created_at #inst "2021-07-02T20:00:35.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+1
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 5, :message "Message 7", :status "pending", :created_at #inst "2021-07-02T19:53:25.000000000-00:00"} {:id 6, :message "1", :status "pending", :created_at #inst "2021-07-02T19:59:51.000000000-00:00"} {:id 7, :message "2", :status "pending", :created_at #inst "2021-07-02T19:59:52.000000000-00:00"} {:id 8, :message "3", :status "pending", :created_at #inst "2021-07-02T19:59:53.000000000-00:00"} {:id 9, :message "4", :status "pending", :created_at #inst "2021-07-02T19:59:53.000000000-00:00"} {:id 10, :message "5", :status "pending", :created_at #inst "2021-07-02T19:59:54.000000000-00:00"} {:id 11, :message "Message 7", :status "pending", :created_at #inst "2021-07-02T20:00:35.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 2, :message "Message 77", :status "hidden", :created_at #inst "2021-07-02T19:52:35.000000000-00:00"} {:id 3, :message "Message 74", :status "hidden", :created_at #inst "2021-07-02T19:53:20.000000000-00:00"} {:id 4, :message "Message 76", :status "hidden", :created_at #inst "2021-07-02T19:53:23.000000000-00:00"} {:id 5, :message "Message 7", :status "pending", :created_at #inst "2021-07-02T19:53:25.000000000-00:00"} {:id 6, :message "1", :status "pending", :created_at #inst "2021-07-02T19:59:51.000000000-00:00"} {:id 7, :message "2", :status "pending", :created_at #inst "2021-07-02T19:59:52.000000000-00:00"} {:id 8, :message "3", :status "pending", :created_at #inst "2021-07-02T19:59:53.000000000-00:00"} {:id 9, :message "4", :status "pending", :created_at #inst "2021-07-02T19:59:53.000000000-00:00"} {:id 10, :message "5", :status "pending", :created_at #inst "2021-07-02T19:59:54.000000000-00:00"} {:id 11, :message "Message 7", :status "pending", :created_at #inst "2021-07-02T20:00:35.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+1
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 3, :message "Message 74", :status "hidden", :created_at #inst "2021-07-02T19:53:20.000000000-00:00"} {:id 4, :message "Message 76", :status "hidden", :created_at #inst "2021-07-02T19:53:23.000000000-00:00"} {:id 5, :message "Message 7", :status "pending", :created_at #inst "2021-07-02T19:53:25.000000000-00:00"} {:id 6, :message "1", :status "pending", :created_at #inst "2021-07-02T19:59:51.000000000-00:00"} {:id 7, :message "2", :status "pending", :created_at #inst "2021-07-02T19:59:52.000000000-00:00"} {:id 8, :message "3", :status "pending", :created_at #inst "2021-07-02T19:59:53.000000000-00:00"} {:id 9, :message "4", :status "pending", :created_at #inst "2021-07-02T19:59:53.000000000-00:00"} {:id 10, :message "5", :status "pending", :created_at #inst "2021-07-02T19:59:54.000000000-00:00"} {:id 11, :message "Message 7", :status "pending", :created_at #inst "2021-07-02T20:00:35.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+; Error printing return value (SQLException) at com.mysql.jdbc.SQLError/createSQLException (SQLError.java:964).
+; Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+clj꞉s71-challenge.queue.actions꞉> 
+({:generated_key 12})
+clj꞉s71-challenge.queue.actions꞉> 
+; Syntax error compiling if at (c:\Users\avera\Documents\Clojure\s71-challenge\src\s71_challenge\queue\actions.clj:109:1).
+; Too few arguments to if
+clj꞉s71-challenge.queue.actions꞉> 
+false
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (IllegalArgumentException) at s71-challenge.queue.actions/eval9834 (form-init4971588882629295352.clj:109).
+; contains? not supported on type: clojure.lang.LazySeq
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/push
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (ArityException) at s71-challenge.queue.actions/eval9847 (form-init4971588882629295352.clj:109).
+; Wrong number of args (1) passed to: clojure.core/contains?
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (ArityException) at s71-challenge.queue.actions/eval9849 (form-init4971588882629295352.clj:109).
+; Wrong number of args (2) passed to: s71-challenge.queue.actions/push
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (IllegalArgumentException) at s71-challenge.queue.actions/eval9851 (form-init4971588882629295352.clj:109).
+; contains? not supported on type: java.lang.String
+clj꞉s71-challenge.queue.actions꞉> 
+"will break"
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/push
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (IllegalArgumentException) at s71-challenge.queue.actions/eval9863 (form-init4971588882629295352.clj:109).
+; contains? not supported on type: clojure.lang.LazySeq
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (ClassCastException) at s71-challenge.queue.actions/eval9867 (form-init4971588882629295352.clj:112).
+; clojure.lang.LazySeq cannot be cast to clojure.lang.IFn
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (ClassCastException) at s71-challenge.queue.actions/eval9877 (form-init4971588882629295352.clj:112).
+; clojure.lang.LazySeq cannot be cast to clojure.lang.IFn
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+([:generated_key 5])
+clj꞉s71-challenge.queue.actions꞉> 
+({:generated_key 13})
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+clojure.lang.LazySeq
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (ClassCastException) at s71-challenge.queue.actions/eval9891 (form-init4971588882629295352.clj:113).
+; clojure.lang.LazySeq cannot be cast to clojure.lang.IFn
+clj꞉s71-challenge.queue.actions꞉> 
+({:generated_key 14})
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+({:generated_key 14})
+clj꞉s71-challenge.queue.actions꞉> 
+({:generated_key 14})
+clj꞉s71-challenge.queue.actions꞉> 
+({:generated_key 14})
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (IllegalArgumentException) at s71-challenge.queue.actions/eval9903 (form-init4971588882629295352.clj:113).
+; No value supplied for key: {:generated_key 14}
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+; Error printing return value (ClassCastException) at clojure.lang.APersistentMap$KeySeq/first (APersistentMap.java:168).
+; clojure.lang.PersistentArrayMap cannot be cast to java.util.Map$Entry
+clj꞉s71-challenge.queue.actions꞉> 
+clojure.lang.LazySeq
+clj꞉s71-challenge.queue.actions꞉> 
+(1 {:generated_key 15})
+clj꞉s71-challenge.queue.actions꞉> 
+(1 {:generated_key 15})
+clj꞉s71-challenge.queue.actions꞉> 
+{:generated_key 15}
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+15
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+(:generated_key)
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+15
+clj꞉s71-challenge.queue.actions꞉> 
+true
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (SQLException) at com.mysql.jdbc.SQLError/createSQLException (SQLError.java:964).
+; Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+clj꞉s71-challenge.queue.actions꞉> 
+java.sql.SQLException
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (SQLException) at com.mysql.jdbc.SQLError/createSQLException (SQLError.java:964).
+; Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+clj꞉s71-challenge.queue.actions꞉> 
+; Syntax error compiling at (c:\Users\avera\Documents\Clojure\s71-challenge\src\s71_challenge\queue\actions.clj:111:3).
+; Unable to resolve symbol: e in this context
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (SQLException) at com.mysql.jdbc.SQLError/createSQLException (SQLError.java:964).
+; Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+clj꞉s71-challenge.queue.actions꞉> 
+#error {
+ :cause throw
+ :via
+ [{:type java.sql.SQLException
+   :message throw
+   :at [s71_challenge.queue.actions$fn__9995 invokeStatic form-init4971588882629295352.clj 111]}]
+ :trace
+ [[s71_challenge.queue.actions$fn__9995 invokeStatic form-init4971588882629295352.clj 111]
+  [s71_challenge.queue.actions$fn__9995 invoke form-init4971588882629295352.clj 111]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.lang.Compiler$InvokeExpr eval Compiler.java 3702]
+  [clojure.lang.Compiler$DefExpr eval Compiler.java 457]
+  [clojure.lang.Compiler eval Compiler.java 7182]
+  [clojure.lang.Compiler eval Compiler.java 7132]
+  [clojure.core$eval invokeStatic core.clj 3214]
+  [clojure.core$eval invoke core.clj 3210]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415$fn__3416 invoke interruptible_eval.clj 87]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.core$apply invokeStatic core.clj 665]
+  [clojure.core$with_bind
+ings_STAR_ invokeStatic core.clj 1973]
+  [clojure.core$with_bindings_STAR_ doInvoke core.clj 1973]
+  [clojure.lang.RestFn invoke RestFn.java 425]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415 invoke interruptible_eval.clj 87]
+  [clojure.main$repl$read_eval_print__9086$fn__9089 invoke main.clj 437]
+  [clojure.main$repl$read_eval_print__9086 invoke main.clj 437]
+  [clojure.main$repl$fn__9095 invoke main.clj 458]
+  [clojure.main$repl invokeStatic main.clj 458]
+  [clojure.main$repl doInvoke main.clj 368]
+  [clojure.lang.RestFn invoke RestFn.java 1523]
+  [nrepl.middleware.interruptible_eval$evaluate invokeStatic interruptible_eval.clj 84]
+  [nrepl.middleware.interruptible_eval$evaluate invoke interruptible_eval.clj 56]
+  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__3446$fn__3450 invoke interruptible_eval.clj 152]
+  [clojure.lang.AFn run AFn.java 22]
+  [nrepl.middleware.session$session_exec$main_loop__3513$fn__3517 invoke session.clj 202]
+  [nrepl.middleware.session$session_exec$main_loop_
+_3513 invoke session.clj 201]
+  [clojure.lang.AFn run AFn.java 22]
+  [java.lang.Thread run nil -1]]}
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+#error {
+ :cause throw
+ :via
+ [{:type java.sql.SQLException
+   :message throw
+   :at [s71_challenge.queue.actions$fn__9999 invokeStatic form-init4971588882629295352.clj 111]}]
+ :trace
+ [[s71_challenge.queue.actions$fn__9999 invokeStatic form-init4971588882629295352.clj 111]
+  [s71_challenge.queue.actions$fn__9999 invoke form-init4971588882629295352.clj 111]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.lang.Compiler$InvokeExpr eval Compiler.java 3702]
+  [clojure.lang.Compiler$DefExpr eval Compiler.java 457]
+  [clojure.lang.Compiler eval Compiler.java 7182]
+  [clojure.lang.Compiler eval Compiler.java 7132]
+  [clojure.core$eval invokeStatic core.clj 3214]
+  [clojure.core$eval invoke core.clj 3210]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415$fn__3416 invoke interruptible_eval.clj 87]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.core$apply invokeStatic core.clj 665]
+  [clojure.core$with_bind
+ings_STAR_ invokeStatic core.clj 1973]
+  [clojure.core$with_bindings_STAR_ doInvoke core.clj 1973]
+  [clojure.lang.RestFn invoke RestFn.java 425]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415 invoke interruptible_eval.clj 87]
+  [clojure.main$repl$read_eval_print__9086$fn__9089 invoke main.clj 437]
+  [clojure.main$repl$read_eval_print__9086 invoke main.clj 437]
+  [clojure.main$repl$fn__9095 invoke main.clj 458]
+  [clojure.main$repl invokeStatic main.clj 458]
+  [clojure.main$repl doInvoke main.clj 368]
+  [clojure.lang.RestFn invoke RestFn.java 1523]
+  [nrepl.middleware.interruptible_eval$evaluate invokeStatic interruptible_eval.clj 84]
+  [nrepl.middleware.interruptible_eval$evaluate invoke interruptible_eval.clj 56]
+  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__3446$fn__3450 invoke interruptible_eval.clj 152]
+  [clojure.lang.AFn run AFn.java 22]
+  [nrepl.middleware.session$session_exec$main_loop__3513$fn__3517 invoke session.clj 202]
+  [nrepl.middleware.session$session_exec$main_loop_
+_3513 invoke session.clj 201]
+  [clojure.lang.AFn run AFn.java 22]
+  [java.lang.Thread run nil -1]]}
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (SQLException) at com.mysql.jdbc.SQLError/createSQLException (SQLError.java:964).
+; Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+clj꞉s71-challenge.queue.actions꞉> 
+#error {
+ :cause throw
+ :via
+ [{:type java.sql.SQLException
+   :message throw
+   :at [s71_challenge.queue.actions$fn__10005 invokeStatic form-init4971588882629295352.clj 111]}]
+ :trace
+ [[s71_challenge.queue.actions$fn__10005 invokeStatic form-init4971588882629295352.clj 111]
+  [s71_challenge.queue.actions$fn__10005 invoke form-init4971588882629295352.clj 111]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.lang.Compiler$InvokeExpr eval Compiler.java 3702]
+  [clojure.lang.Compiler$DefExpr eval Compiler.java 457]
+  [clojure.lang.Compiler eval Compiler.java 7182]
+  [clojure.lang.Compiler eval Compiler.java 7132]
+  [clojure.core$eval invokeStatic core.clj 3214]
+  [clojure.core$eval invoke core.clj 3210]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415$fn__3416 invoke interruptible_eval.clj 87]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.core$apply invokeStatic core.clj 665]
+  [clojure.core$with_b
+indings_STAR_ invokeStatic core.clj 1973]
+  [clojure.core$with_bindings_STAR_ doInvoke core.clj 1973]
+  [clojure.lang.RestFn invoke RestFn.java 425]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415 invoke interruptible_eval.clj 87]
+  [clojure.main$repl$read_eval_print__9086$fn__9089 invoke main.clj 437]
+  [clojure.main$repl$read_eval_print__9086 invoke main.clj 437]
+  [clojure.main$repl$fn__9095 invoke main.clj 458]
+  [clojure.main$repl invokeStatic main.clj 458]
+  [clojure.main$repl doInvoke main.clj 368]
+  [clojure.lang.RestFn invoke RestFn.java 1523]
+  [nrepl.middleware.interruptible_eval$evaluate invokeStatic interruptible_eval.clj 84]
+  [nrepl.middleware.interruptible_eval$evaluate invoke interruptible_eval.clj 56]
+  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__3446$fn__3450 invoke interruptible_eval.clj 152]
+  [clojure.lang.AFn run AFn.java 22]
+  [nrepl.middleware.session$session_exec$main_loop__3513$fn__3517 invoke session.clj 202]
+  [nrepl.middleware.session$session_exec$main_lo
+op__3513 invoke session.clj 201]
+  [clojure.lang.AFn run AFn.java 22]
+  [java.lang.Thread run nil -1]]}
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+; Syntax error compiling at (c:\Users\avera\Documents\Clojure\s71-challenge\src\s71_challenge\queue\actions.clj:111:12).
+; Expecting var, but SQLException is mapped to class java.sql.SQLException
+clj꞉s71-challenge.queue.actions꞉> 
+#error {
+ :cause throw
+ :via
+ [{:type java.sql.SQLException
+   :message throw
+   :at [s71_challenge.queue.actions$fn__10012 invokeStatic form-init4971588882629295352.clj 111]}]
+ :trace
+ [[s71_challenge.queue.actions$fn__10012 invokeStatic form-init4971588882629295352.clj 111]
+  [s71_challenge.queue.actions$fn__10012 invoke form-init4971588882629295352.clj 111]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.lang.Compiler$InvokeExpr eval Compiler.java 3702]
+  [clojure.lang.Compiler$DefExpr eval Compiler.java 457]
+  [clojure.lang.Compiler eval Compiler.java 7182]
+  [clojure.lang.Compiler eval Compiler.java 7132]
+  [clojure.core$eval invokeStatic core.clj 3214]
+  [clojure.core$eval invoke core.clj 3210]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415$fn__3416 invoke interruptible_eval.clj 87]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.core$apply invokeStatic core.clj 665]
+  [clojure.core$with_b
+indings_STAR_ invokeStatic core.clj 1973]
+  [clojure.core$with_bindings_STAR_ doInvoke core.clj 1973]
+  [clojure.lang.RestFn invoke RestFn.java 425]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415 invoke interruptible_eval.clj 87]
+  [clojure.main$repl$read_eval_print__9086$fn__9089 invoke main.clj 437]
+  [clojure.main$repl$read_eval_print__9086 invoke main.clj 437]
+  [clojure.main$repl$fn__9095 invoke main.clj 458]
+  [clojure.main$repl invokeStatic main.clj 458]
+  [clojure.main$repl doInvoke main.clj 368]
+  [clojure.lang.RestFn invoke RestFn.java 1523]
+  [nrepl.middleware.interruptible_eval$evaluate invokeStatic interruptible_eval.clj 84]
+  [nrepl.middleware.interruptible_eval$evaluate invoke interruptible_eval.clj 56]
+  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__3446$fn__3450 invoke interruptible_eval.clj 152]
+  [clojure.lang.AFn run AFn.java 22]
+  [nrepl.middleware.session$session_exec$main_loop__3513$fn__3517 invoke session.clj 202]
+  [nrepl.middleware.session$session_exec$main_lo
+op__3513 invoke session.clj 201]
+  [clojure.lang.AFn run AFn.java 22]
+  [java.lang.Thread run nil -1]]}
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+#error {
+ :cause throw
+ :via
+ [{:type java.sql.SQLException
+   :message throw
+   :at [s71_challenge.queue.actions$fn__10016 invokeStatic form-init4971588882629295352.clj 111]}]
+ :trace
+ [[s71_challenge.queue.actions$fn__10016 invokeStatic form-init4971588882629295352.clj 111]
+  [s71_challenge.queue.actions$fn__10016 invoke form-init4971588882629295352.clj 111]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.lang.Compiler$InvokeExpr eval Compiler.java 3702]
+  [clojure.lang.Compiler$DefExpr eval Compiler.java 457]
+  [clojure.lang.Compiler eval Compiler.java 7182]
+  [clojure.lang.Compiler eval Compiler.java 7132]
+  [clojure.core$eval invokeStatic core.clj 3214]
+  [clojure.core$eval invoke core.clj 3210]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415$fn__3416 invoke interruptible_eval.clj 87]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.core$apply invokeStatic core.clj 665]
+  [clojure.core$with_b
+indings_STAR_ invokeStatic core.clj 1973]
+  [clojure.core$with_bindings_STAR_ doInvoke core.clj 1973]
+  [clojure.lang.RestFn invoke RestFn.java 425]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415 invoke interruptible_eval.clj 87]
+  [clojure.main$repl$read_eval_print__9086$fn__9089 invoke main.clj 437]
+  [clojure.main$repl$read_eval_print__9086 invoke main.clj 437]
+  [clojure.main$repl$fn__9095 invoke main.clj 458]
+  [clojure.main$repl invokeStatic main.clj 458]
+  [clojure.main$repl doInvoke main.clj 368]
+  [clojure.lang.RestFn invoke RestFn.java 1523]
+  [nrepl.middleware.interruptible_eval$evaluate invokeStatic interruptible_eval.clj 84]
+  [nrepl.middleware.interruptible_eval$evaluate invoke interruptible_eval.clj 56]
+  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__3446$fn__3450 invoke interruptible_eval.clj 152]
+  [clojure.lang.AFn run AFn.java 22]
+  [nrepl.middleware.session$session_exec$main_loop__3513$fn__3517 invoke session.clj 202]
+  [nrepl.middleware.session$session_exec$main_lo
+op__3513 invoke session.clj 201]
+  [clojure.lang.AFn run AFn.java 22]
+  [java.lang.Thread run nil -1]]}
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+#error {
+ :cause throw
+ :via
+ [{:type java.sql.SQLException
+   :message throw
+   :at [s71_challenge.queue.actions$fn__10018 invokeStatic form-init4971588882629295352.clj 111]}]
+ :trace
+ [[s71_challenge.queue.actions$fn__10018 invokeStatic form-init4971588882629295352.clj 111]
+  [s71_challenge.queue.actions$fn__10018 invoke form-init4971588882629295352.clj 111]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.lang.Compiler$InvokeExpr eval Compiler.java 3702]
+  [clojure.lang.Compiler$DefExpr eval Compiler.java 457]
+  [clojure.lang.Compiler eval Compiler.java 7182]
+  [clojure.lang.Compiler eval Compiler.java 7132]
+  [clojure.core$eval invokeStatic core.clj 3214]
+  [clojure.core$eval invoke core.clj 3210]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415$fn__3416 invoke interruptible_eval.clj 87]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.core$apply invokeStatic core.clj 665]
+  [clojure.core$with_b
+indings_STAR_ invokeStatic core.clj 1973]
+  [clojure.core$with_bindings_STAR_ doInvoke core.clj 1973]
+  [clojure.lang.RestFn invoke RestFn.java 425]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415 invoke interruptible_eval.clj 87]
+  [clojure.main$repl$read_eval_print__9086$fn__9089 invoke main.clj 437]
+  [clojure.main$repl$read_eval_print__9086 invoke main.clj 437]
+  [clojure.main$repl$fn__9095 invoke main.clj 458]
+  [clojure.main$repl invokeStatic main.clj 458]
+  [clojure.main$repl doInvoke main.clj 368]
+  [clojure.lang.RestFn invoke RestFn.java 1523]
+  [nrepl.middleware.interruptible_eval$evaluate invokeStatic interruptible_eval.clj 84]
+  [nrepl.middleware.interruptible_eval$evaluate invoke interruptible_eval.clj 56]
+  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__3446$fn__3450 invoke interruptible_eval.clj 152]
+  [clojure.lang.AFn run AFn.java 22]
+  [nrepl.middleware.session$session_exec$main_loop__3513$fn__3517 invoke session.clj 202]
+  [nrepl.middleware.session$session_exec$main_lo
+op__3513 invoke session.clj 201]
+  [clojure.lang.AFn run AFn.java 22]
+  [java.lang.Thread run nil -1]]}
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/t
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (SQLException) at com.mysql.jdbc.SQLError/createSQLException (SQLError.java:964).
+; Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+clj꞉s71-challenge.queue.actions꞉> 
+; Evaluating file: actions.clj
+; Syntax error compiling def at (C:\Users\avera\Documents\Clojure\s71-challenge\src\s71_challenge\queue\actions.clj:122:1).
+; Too many arguments to def
+; Evaluation of file actions.clj failed: class clojure.lang.Compiler$CompilerException
+
+clj꞉s71-challenge.queue.actions꞉> 
+clj꞉s71-challenge.queue.actions꞉> 
+; Syntax error compiling def at (c:\Users\avera\Documents\Clojure\s71-challenge\src\s71_challenge\queue\actions.clj:122:1).
+; Too many arguments to def
+clj꞉s71-challenge.queue.actions꞉> 
+; Syntax error macroexpanding clojure.core/defn at (c:\Users\avera\Documents\Clojure\s71-challenge\src\s71_challenge\queue\actions.clj:122:1).
+; push - failed: vector? at: [:fn-tail :arity-n :bodies :params] spec: :clojure.core.specs.alpha/param-list
+(push ["will break" {:t 2}]) - failed: vector? at: [:fn-tail :arity-1 :params] spec: :clojure.core.specs.alpha/param-list
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/err
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (ArityException) at s71-challenge.queue.actions/err (form-init4971588882629295352.clj:124).
+; Wrong number of args (0) passed to: clojure.java.jdbc/print-sql-exception
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/err
+clj꞉s71-challenge.queue.actions꞉> 
+; Error printing return value (SQLException) at com.mysql.jdbc.SQLError/createSQLException (SQLError.java:964).
+; Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/err
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (ClassCastException) at clojure.java.jdbc/print-sql-exception (jdbc.clj:695).
+; java.lang.ClassCastException cannot be cast to java.sql.SQLException
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/err
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (ClassCastException) at clojure.java.jdbc/print-sql-exception (jdbc.clj:695).
+; java.lang.ClassCastException cannot be cast to java.sql.SQLException
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/err
+clj꞉s71-challenge.queue.actions꞉> 
+#error {
+ :cause java.lang.Class cannot be cast to java.lang.Throwable
+ :via
+ [{:type java.lang.ClassCastException
+   :message java.lang.Class cannot be cast to java.lang.Throwable
+   :at [s71_challenge.queue.actions$err invokeStatic form-init4971588882629295352.clj 122]}]
+ :trace
+ [[s71_challenge.queue.actions$err invokeStatic form-init4971588882629295352.clj 122]
+  [s71_challenge.queue.actions$err invoke form-init4971588882629295352.clj 122]
+  [s71_challenge.queue.actions$eval10084 invokeStatic form-init4971588882629295352.clj 130]
+  [s71_challenge.queue.actions$eval10084 invoke form-init4971588882629295352.clj 130]
+  [clojure.lang.Compiler eval Compiler.java 7177]
+  [clojure.lang.Compiler eval Compiler.java 7132]
+  [clojure.core$eval invokeStatic core.clj 3214]
+  [clojure.core$eval invoke core.clj 3210]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415$fn__3416 invoke interruptible_eval.clj 87]
+  [clojure.lang.AFn applyToHelper AFn.java 152]
+  [clojure.lang.AFn applyTo AFn.java 144]
+  [clojure.core$
+apply invokeStatic core.clj 665]
+  [clojure.core$with_bindings_STAR_ invokeStatic core.clj 1973]
+  [clojure.core$with_bindings_STAR_ doInvoke core.clj 1973]
+  [clojure.lang.RestFn invoke RestFn.java 425]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3415 invoke interruptible_eval.clj 87]
+  [clojure.main$repl$read_eval_print__9086$fn__9089 invoke main.clj 437]
+  [clojure.main$repl$read_eval_print__9086 invoke main.clj 437]
+  [clojure.main$repl$fn__9095 invoke main.clj 458]
+  [clojure.main$repl invokeStatic main.clj 458]
+  [clojure.main$repl doInvoke main.clj 368]
+  [clojure.lang.RestFn invoke RestFn.java 1523]
+  [nrepl.middleware.interruptible_eval$evaluate invokeStatic interruptible_eval.clj 84]
+  [nrepl.middleware.interruptible_eval$evaluate invoke interruptible_eval.clj 56]
+  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__3446$fn__3450 invoke interruptible_eval.clj 152]
+  [clojure.lang.AFn run AFn.java 22]
+  [nrepl.middleware.session$session_exec$main_loop__3513$fn__3517 invoke session.cl
+j 202]
+  [nrepl.middleware.session$session_exec$main_loop__3513 invoke session.clj 201]
+  [clojure.lang.AFn run AFn.java 22]
+  [java.lang.Thread run nil -1]]}
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/err
+clj꞉s71-challenge.queue.actions꞉> 
+; Error printing return value (SQLException) at com.mysql.jdbc.SQLError/createSQLException (SQLError.java:964).
+; Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+clj꞉s71-challenge.queue.actions꞉> 
+[0]
+clj꞉s71-challenge.queue.actions꞉> 
+[0]
+clj꞉s71-challenge.queue.actions꞉> 
+()
+clj꞉s71-challenge.queue.actions꞉> 
+; Error printing return value (SQLException) at com.mysql.jdbc.SQLError/createSQLException (SQLError.java:964).
+; Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 1, :message "will break", :status "pending", :created_at #inst "2021-07-02T20:43:41.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+({:generated_key 5} {:generated_key 6})
+clj꞉s71-challenge.queue.actions꞉> 
+nil
+clj꞉s71-challenge.queue.actions꞉> 
+(5 6)
+clj꞉s71-challenge.queue.actions꞉> 
+(5 nil 6)
+clj꞉s71-challenge.queue.actions꞉> 
+; Error printing return value (ArityException) at clojure.lang.AFn/throwArity (AFn.java:429).
+; Wrong number of args (1) passed to: s71-challenge.queue.actions/eval10107/fn--10108
+clj꞉s71-challenge.queue.actions꞉> 
+(true false true)
+clj꞉s71-challenge.queue.actions꞉> 
+()
+clj꞉s71-challenge.queue.actions꞉> 
+; Error printing return value (SQLException) at com.mysql.jdbc.SQLError/createSQLException (SQLError.java:964).
+; Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+clj꞉s71-challenge.queue.actions꞉> 
+; Error printing return value (SQLException) at com.mysql.jdbc.SQLError/createSQLException (SQLError.java:964).
+; Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/push
+clj꞉s71-challenge.queue.actions꞉> 
+#function[clojure.core/map/fn--5862]
+clj꞉s71-challenge.queue.actions꞉> 
+#function[clojure.core/map/fn--5862]
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/push
+clj꞉s71-challenge.queue.actions꞉> 
+#error {
+ :cause Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+ :via
+ [{:type java.sql.SQLException
+   :message Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+   :at [com.mysql.jdbc.SQLError createSQLException SQLError.java 964]}]
+ :trace
+ [[com.mysql.jdbc.SQLError createSQLException SQLError.java 964]
+  [com.mysql.jdbc.MysqlIO checkErrorPacket MysqlIO.java 3973]
+  [com.mysql.jdbc.MysqlIO checkErrorPacket MysqlIO.java 3909]
+  [com.mysql.jdbc.MysqlIO sendCommand MysqlIO.java 2527]
+  [com.mysql.jdbc.MysqlIO sqlQueryDirect MysqlIO.java 2680]
+  [com.mysql.jdbc.ConnectionImpl execSQL ConnectionImpl.java 2487]
+  [com.mysql.jdbc.PreparedStatement executeInternal PreparedStatement.java 1858]
+  [com.mysql.jdbc.PreparedStatement executeUpdateInternal PreparedStatement.java 2079]
+  [com.mysql.jdbc.PreparedStatement executeUpdateInternal PreparedStatement.java 2013]
+  [com.mysql.jdbc.PreparedStatement executeLargeUpdate PreparedStatement.java 5104]
+  [com.mys
+ql.jdbc.PreparedStatement executeUpdate PreparedStatement.java 1998]
+  [clojure.java.jdbc$db_do_execute_prepared_return_keys$exec_and_return_keys__562 invoke jdbc.clj 979]
+  [clojure.java.jdbc$db_do_execute_prepared_return_keys$fn__571 invoke jdbc.clj 1006]
+  [clojure.java.jdbc$db_transaction_STAR_ invokeStatic jdbc.clj 807]
+  [clojure.java.jdbc$db_transaction_STAR_ invoke jdbc.clj 776]
+  [clojure.java.jdbc$db_transaction_STAR_ invokeStatic jdbc.clj 789]
+  [clojure.java.jdbc$db_transaction_STAR_ invoke jdbc.clj 776]
+  [clojure.java.jdbc$db_do_execute_prepared_return_keys invokeStatic jdbc.clj 1005]
+  [clojure.java.jdbc$db_do_execute_prepared_return_keys invoke jdbc.clj 963]
+  [clojure.java.jdbc$db_do_prepared_return_keys invokeStatic jdbc.clj 1038]
+  [clojure.java.jdbc$db_do_prepared_return_keys invoke jdbc.clj 1015]
+  [clojure.java.jdbc$db_do_prepared_return_keys invokeStatic jdbc.clj 1040]
+  [clojure.java.jdbc$db_do_prepared_return_keys invoke jdbc.clj 1015]
+  [clojure.java.jdbc$db_do_prepared_return_keys i
+nvokeStatic jdbc.clj 1023]
+  [clojure.java.jdbc$db_do_prepared_return_keys invoke jdbc.clj 1015]
+  [hugsql.adapter.clojure_java_jdbc.HugsqlAdapterClojureJavaJdbc execute clojure_java_jdbc.clj 11]
+  [hugsql.adapter$eval1603$fn__1604$G__1583__1609 invoke adapter.clj 3]
+  [hugsql.adapter$eval1603$fn__1604$G__1582__1615 invoke adapter.clj 3]
+  [clojure.lang.Var invoke Var.java 399]
+  [hugsql.core$db_fn_STAR_$y__2513 doInvoke core.clj 458]
+  [clojure.lang.RestFn invoke RestFn.java 445]
+  [hugsql.core$db_fn_STAR_$y__2513 invoke core.clj 448]
+  [s71_challenge.queue.actions$push$fn__10150 invoke form-init4971588882629295352.clj 109]
+  [clojure.core$map$fn__5866 invoke core.clj 2755]
+  [clojure.lang.LazySeq sval LazySeq.java 42]
+  [clojure.lang.LazySeq seq LazySeq.java 51]
+  [clojure.lang.RT seq RT.java 535]
+  [clojure.core$seq__5402 invokeStatic core.clj 137]
+  [clojure.core$print_sequential invokeStatic core_print.clj 53]
+  [clojure.core$fn__7310 invokeStatic core_print.clj 174]
+  [clojure.core$fn__7310 invoke core_
+print.clj 174]
+  [clojure.lang.MultiFn invoke MultiFn.java 234]
+  [nrepl.middleware.print$pr_on invokeStatic print.clj 21]
+  [nrepl.middleware.print$pr_on invoke print.clj 17]
+  [nrepl.middleware.print$send_nonstreamed$print_key__3320$fn__3321 invoke print.clj 148]
+  [nrepl.middleware.print$send_nonstreamed$print_key__3320 invoke print.clj 147]
+  [clojure.core$map$fn__5862$fn__5863 invoke core.clj 2742]
+  [clojure.core.protocols$iter_reduce invokeStatic protocols.clj 49]
+  [clojure.core.protocols$fn__8140 invokeStatic protocols.clj 75]
+  [clojure.core.protocols$fn__8140 invoke protocols.clj 75]
+  [clojure.core.protocols$fn__8088$G__8083__8101 invoke protocols.clj 13]
+  [clojure.core$transduce invokeStatic core.clj 6884]
+  [clojure.core$transduce invoke core.clj 6870]
+  [nrepl.middleware.print$send_nonstreamed invokeStatic print.clj 156]
+  [nrepl.middleware.print$send_nonstreamed invoke print.clj 138]
+  [nrepl.middleware.print$printing_transport$reify__3337 send print.clj 174]
+  [nrepl.middleware.caught$caught
+_transport$reify__3372 send caught.clj 58]
+  [cider.nrepl.middleware.track_state$make_transport$reify__5975 send track_state.clj 228]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3436 invoke interruptible_eval.clj 123]
+  [clojure.main$repl$read_eval_print__9086 invoke main.clj 442]
+  [clojure.main$repl$fn__9095 invoke main.clj 458]
+  [clojure.main$repl invokeStatic main.clj 458]
+  [clojure.main$repl doInvoke main.clj 368]
+  [clojure.lang.RestFn invoke RestFn.java 1523]
+  [nrepl.middleware.interruptible_eval$evaluate invokeStatic interruptible_eval.clj 84]
+  [nrepl.middleware.interruptible_eval$evaluate invoke interruptible_eval.clj 56]
+  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__3446$fn__3450 invoke interruptible_eval.clj 152]
+  [clojure.lang.AFn run AFn.java 22]
+  [nrepl.middleware.session$session_exec$main_loop__3513$fn__3517 invoke session.clj 202]
+  [nrepl.middleware.session$session_exec$main_loop__3513 invoke session.clj 201]
+  [clojure.lang.AFn run AFn.java 22]
+  [java.lang.Thre
+ad run nil -1]]}
+(nil)
+clj꞉s71-challenge.queue.actions꞉> 
+#error {
+ :cause Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+ :via
+ [{:type java.sql.SQLException
+   :message Incorrect string value: '\xAC\xED\x00\x05sr...' for column 'message' at row 1
+   :at [com.mysql.jdbc.SQLError createSQLException SQLError.java 964]}]
+ :trace
+ [[com.mysql.jdbc.SQLError createSQLException SQLError.java 964]
+  [com.mysql.jdbc.MysqlIO checkErrorPacket MysqlIO.java 3973]
+  [com.mysql.jdbc.MysqlIO checkErrorPacket MysqlIO.java 3909]
+  [com.mysql.jdbc.MysqlIO sendCommand MysqlIO.java 2527]
+  [com.mysql.jdbc.MysqlIO sqlQueryDirect MysqlIO.java 2680]
+  [com.mysql.jdbc.ConnectionImpl execSQL ConnectionImpl.java 2487]
+  [com.mysql.jdbc.PreparedStatement executeInternal PreparedStatement.java 1858]
+  [com.mysql.jdbc.PreparedStatement executeUpdateInternal PreparedStatement.java 2079]
+  [com.mysql.jdbc.PreparedStatement executeUpdateInternal PreparedStatement.java 2013]
+  [com.mysql.jdbc.PreparedStatement executeLargeUpdate PreparedStatement.java 5104]
+  [com.mys
+ql.jdbc.PreparedStatement executeUpdate PreparedStatement.java 1998]
+  [clojure.java.jdbc$db_do_execute_prepared_return_keys$exec_and_return_keys__562 invoke jdbc.clj 979]
+  [clojure.java.jdbc$db_do_execute_prepared_return_keys$fn__571 invoke jdbc.clj 1006]
+  [clojure.java.jdbc$db_transaction_STAR_ invokeStatic jdbc.clj 807]
+  [clojure.java.jdbc$db_transaction_STAR_ invoke jdbc.clj 776]
+  [clojure.java.jdbc$db_transaction_STAR_ invokeStatic jdbc.clj 789]
+  [clojure.java.jdbc$db_transaction_STAR_ invoke jdbc.clj 776]
+  [clojure.java.jdbc$db_do_execute_prepared_return_keys invokeStatic jdbc.clj 1005]
+  [clojure.java.jdbc$db_do_execute_prepared_return_keys invoke jdbc.clj 963]
+  [clojure.java.jdbc$db_do_prepared_return_keys invokeStatic jdbc.clj 1038]
+  [clojure.java.jdbc$db_do_prepared_return_keys invoke jdbc.clj 1015]
+  [clojure.java.jdbc$db_do_prepared_return_keys invokeStatic jdbc.clj 1040]
+  [clojure.java.jdbc$db_do_prepared_return_keys invoke jdbc.clj 1015]
+  [clojure.java.jdbc$db_do_prepared_return_keys i
+nvokeStatic jdbc.clj 1023]
+  [clojure.java.jdbc$db_do_prepared_return_keys invoke jdbc.clj 1015]
+  [hugsql.adapter.clojure_java_jdbc.HugsqlAdapterClojureJavaJdbc execute clojure_java_jdbc.clj 11]
+  [hugsql.adapter$eval1603$fn__1604$G__1583__1609 invoke adapter.clj 3]
+  [hugsql.adapter$eval1603$fn__1604$G__1582__1615 invoke adapter.clj 3]
+  [clojure.lang.Var invoke Var.java 399]
+  [hugsql.core$db_fn_STAR_$y__2513 doInvoke core.clj 458]
+  [clojure.lang.RestFn invoke RestFn.java 445]
+  [hugsql.core$db_fn_STAR_$y__2513 invoke core.clj 448]
+  [s71_challenge.queue.actions$push$fn__10150 invoke form-init4971588882629295352.clj 109]
+  [clojure.core$map$fn__5866 invoke core.clj 2753]
+  [clojure.lang.LazySeq sval LazySeq.java 42]
+  [clojure.lang.LazySeq seq LazySeq.java 51]
+  [clojure.lang.RT seq RT.java 535]
+  [clojure.core$seq__5402 invokeStatic core.clj 137]
+  [clojure.core$print_sequential invokeStatic core_print.clj 53]
+  [clojure.core$fn__7310 invokeStatic core_print.clj 174]
+  [clojure.core$fn__7310 invoke core_
+print.clj 174]
+  [clojure.lang.MultiFn invoke MultiFn.java 234]
+  [nrepl.middleware.print$pr_on invokeStatic print.clj 21]
+  [nrepl.middleware.print$pr_on invoke print.clj 17]
+  [nrepl.middleware.print$send_nonstreamed$print_key__3320$fn__3321 invoke print.clj 148]
+  [nrepl.middleware.print$send_nonstreamed$print_key__3320 invoke print.clj 147]
+  [clojure.core$map$fn__5862$fn__5863 invoke core.clj 2742]
+  [clojure.core.protocols$iter_reduce invokeStatic protocols.clj 49]
+  [clojure.core.protocols$fn__8140 invokeStatic protocols.clj 75]
+  [clojure.core.protocols$fn__8140 invoke protocols.clj 75]
+  [clojure.core.protocols$fn__8088$G__8083__8101 invoke protocols.clj 13]
+  [clojure.core$transduce invokeStatic core.clj 6884]
+  [clojure.core$transduce invoke core.clj 6870]
+  [nrepl.middleware.print$send_nonstreamed invokeStatic print.clj 156]
+  [nrepl.middleware.print$send_nonstreamed invoke print.clj 138]
+  [nrepl.middleware.print$printing_transport$reify__3337 send print.clj 174]
+  [nrepl.middleware.caught$caught
+_transport$reify__3372 send caught.clj 58]
+  [cider.nrepl.middleware.track_state$make_transport$reify__5975 send track_state.clj 228]
+  [nrepl.middleware.interruptible_eval$evaluate$fn__3436 invoke interruptible_eval.clj 123]
+  [clojure.main$repl$read_eval_print__9086 invoke main.clj 442]
+  [clojure.main$repl$fn__9095 invoke main.clj 458]
+  [clojure.main$repl invokeStatic main.clj 458]
+  [clojure.main$repl doInvoke main.clj 368]
+  [clojure.lang.RestFn invoke RestFn.java 1523]
+  [nrepl.middleware.interruptible_eval$evaluate invokeStatic interruptible_eval.clj 84]
+  [nrepl.middleware.interruptible_eval$evaluate invoke interruptible_eval.clj 56]
+  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__3446$fn__3450 invoke interruptible_eval.clj 152]
+  [clojure.lang.AFn run AFn.java 22]
+  [nrepl.middleware.session$session_exec$main_loop__3513$fn__3517 invoke session.clj 202]
+  [nrepl.middleware.session$session_exec$main_loop__3513 invoke session.clj 201]
+  [clojure.lang.AFn run AFn.java 22]
+  [java.lang.Thre
+ad run nil -1]]}
+({:generated_key 2} nil)
+clj꞉s71-challenge.queue.actions꞉> 
+; Syntax error compiling try at (c:\Users\avera\Documents\Clojure\s71-challenge\src\s71_challenge\queue\actions.clj:108:9).
+; Only catch or finally clause can follow catch in try expression
+clj꞉s71-challenge.queue.actions꞉> 
+; Syntax error compiling if at (c:\Users\avera\Documents\Clojure\s71-challenge\src\s71_challenge\queue\actions.clj:108:9).
+; Too many arguments to if
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/push
+clj꞉s71-challenge.queue.actions꞉> 
+(true false)
+clj꞉s71-challenge.queue.actions꞉> 
+[0]
+clj꞉s71-challenge.queue.actions꞉> 
+; Execution error (MySQLSyntaxErrorException) at sun.reflect.NativeConstructorAccessorImpl/newInstance0 (REPL:-2).
+; Unknown table 'MWej27axH8.KrayzelKueue'
+clj꞉s71-challenge.queue.actions꞉> 
+[0]
+clj꞉s71-challenge.queue.actions꞉> 
+#'s71-challenge.queue.actions/push
+clj꞉s71-challenge.queue.actions꞉> 
+(true false true)
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 1, :message "Prior", :status "pending", :created_at #inst "2021-07-02T20:58:25.000000000-00:00"} {:id 2, :message "After", :status "pending", :created_at #inst "2021-07-02T20:58:27.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+1
+clj꞉s71-challenge.queue.actions꞉> 
+1
+clj꞉s71-challenge.queue.actions꞉> 
+(true false true)
+clj꞉s71-challenge.queue.actions꞉> 
+({:id 3, :message "Prior", :status "pending", :created_at #inst "2021-07-02T20:59:27.000000000-00:00"} {:id 4, :message "After", :status "pending", :created_at #inst "2021-07-02T20:59:28.000000000-00:00"})
+clj꞉s71-challenge.queue.actions꞉> 
+1
+clj꞉s71-challenge.queue.actions꞉> 
+1
+clj꞉s71-challenge.queue.actions꞉> 

--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [mysql-queue "1.1.0"]
                  [org.clojure/java.jdbc "0.7.12"]
                  [mysql/mysql-connector-java "5.1.44"]
-                 [org.clojure/clojure-contrib "1.2.0"]]
+                 [com.layerware/hugsql "0.5.1"]
+                 [org.clojure/core.async "0.4.500"]]
   :repl-options {:init-ns s71-challenge.core})

--- a/resources/queries.sql
+++ b/resources/queries.sql
@@ -1,0 +1,30 @@
+-- :name create-KrayzelKueue-table
+-- :command :execute
+-- :result :raw
+-- :doc creates the MySQL table with appropriate fields
+CREATE TABLE KrayzelKueue (
+    id SERIAL PRIMARY KEY,
+    `message` VARCHAR(255) NOT NULL,
+    `status` VARCHAR(10) DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP());
+
+-- :name get-messages :? :*
+SELECT * FROM KrayzelKueue
+WHERE `status` = 'pending';
+
+-- :name get-hidden-messages :? :*
+SELECT * FROM KrayzelKueue;
+
+-- :name add-message :insert :*
+INSERT INTO KrayzelKueue (message)
+VALUES (:message);
+
+-- :name update-message-status :! :1
+UPDATE KrayzelKueue SET `status` = :status
+WHERE id = :id;
+
+-- :name confirm-message :! :1
+DELETE FROM KrayzelKueue WHERE id = :id;
+
+-- :name delete-table :!
+DROP TABLE KrayzelKueue

--- a/src/s71_challenge/core.clj
+++ b/src/s71_challenge/core.clj
@@ -1,6 +1,7 @@
-(ns s71-challenge.core)
+(ns s71-challenge.core
+  (:require [s71-challenge.queue.actions :refer [push pop peek confirm queue-length]]))
 
-(defn foo
+(defn main
   "I don't do a whole lot."
   [x]
   (println x "Hello, World!"))

--- a/src/s71_challenge/db.clj
+++ b/src/s71_challenge/db.clj
@@ -1,8 +1,8 @@
 (ns s71-challenge.db
-  (:require [clojure.java.jdbc :as j]))
+  (:require [hugsql.core :as hugsql]))
 
 
-(def db-conn {:dbtype "mysql"
+(def config {:dbtype "mysql"
               :dbname "MWej27axH8"
               :host "s71-backend-dev-test.cklodqxnwcql.us-east-1.rds.amazonaws.com"
               :port "3306"
@@ -11,6 +11,18 @@
               :enabledTLSProtocols "TLSv1.2"})
 
 
-(defn s
-  []
-  (j/query db-conn ["SHOW FULL TABLES;"]))
+
+(hugsql/def-db-fns "queries.sql")
+
+
+; Scratchpad for comparing times
+
+;; (defn now [] (new java.util.Date))
+
+
+;; (defn calc-time []
+;;   (let [time1 (now)]
+;;     (Thread/sleep 500)
+;;     (- (inst-ms (now)) (inst-ms time1))))
+
+;; (calc-time)

--- a/src/s71_challenge/queue/actions.clj
+++ b/src/s71_challenge/queue/actions.clj
@@ -1,6 +1,26 @@
-(ns s71-challenge.mysql-queue)
+(ns s71-challenge.queue.actions
+  (:require [s71-challenge.db :as db]
+            [clojure.java.jdbc :as j]))
 
-; The challenge objective is to create a FiFo multi-queue with messages stored in a MySQL database, with an implementation that is independent of test data or use case.
+(import java.sql.SQLException)
+
+
+(db/delete-table db/config)
+(db/create-KrayzelKueue-table db/config)
+(db/add-message db/config {:message "Message 7"})
+(db/get-hidden-messages db/config)
+
+(let [first-id (:id (first (db/get-hidden-messages db/config)))]
+  first-id)
+(db/get-messages db/config)
+
+(db/update-message-status db/config {:status "hidden"
+                                     :id 3})
+(db/confirm-message db/config {:id 2})
+
+
+; The challenge objective is to create a FiFo multi-queue with messages stored in a MySQL database, with an implementation
+; that is independent of test data or use case.
 ; 
 ; In addition your application should...
 ; 1. Fill in the logic for all of the stubbed functions modifying the namespace as needed to develop the queue application.
@@ -12,13 +32,24 @@
 ; 
 ; Your completed files can be submitted as a zip file, GitHub repo, or GitHub gist. 
 
+
 (defn push
   "Pushes the given messages to the queue.
    Returns a list of booleans indicating whether or not each message
    was successfully added to the queue."
   [messages]
-  ;; TODO implement this function
-)
+  
+  ; Iterates over the messages collection by attempting to add the message to the queue
+  ; If a SQLException is thrown, the result for the returned list is False
+  ; Otherwise, a generated_key hash-map will be returned to indicate successfully adding  
+  (map #(if (:generated_key
+             (try
+               (db/add-message db/config {:message %})
+               (catch SQLException e)))
+          true
+          false)
+       messages))
+
 
 (defn peek
   "Returns one or more messages from the queue.
@@ -27,8 +58,10 @@
      message-type - filters for messages of the given type
      limit - returns the given number of messages (default: 1)"
   [& {:keys [message-type limit]}]
-  ;; TODO implement this function
-)
+  (let [limit (if (nil? limit) 1 limit)]
+    (println message-type)
+    (println limit)))
+
 
 (defn pop
   "Returns one or more messages from the queue.
@@ -38,8 +71,12 @@
      message-type - filters for messages of the given type
      limit - returns the given number of messages (default: 1)"
   [ttl & {:keys [message-type limit]}]
+  (let [limit (if (nil? limit) 1 limit)]
+    (println message-type)
+    (println limit))
+
   ;; TODO implement this function
-)
+  )
 
 (defn confirm
   "Deletes the given messages from the queue.
@@ -47,7 +84,7 @@
    of messages returned by the pop function."
   [messages]
   ;; TODO implement this function
-)
+  )
 
 (defn queue-length
   "Returns a count of the number of messages on the queue.
@@ -57,4 +94,6 @@
                     popped but not confirmed"
   [& {:keys [message-type with-hidden?]}]
   ;; TODO implement this function
-)
+  (if with-hidden?
+    "make hidden call"
+    "Do not"))

--- a/src/s71_challenge/queue/app.clj
+++ b/src/s71_challenge/queue/app.clj
@@ -1,0 +1,76 @@
+(ns s71-challenge.queue.app)
+
+
+
+
+
+;; ;; We'll use `conj` to add to the structure
+;; ;; And then `seq` to look at the queues contents
+
+;; (def numbers-in (queue [1 2 3 4 5]))
+;; (seq numbers-in)
+;; ;;=> (1 2 3 4 5)
+
+;; ;; We can use `pop` and `peek` as expected
+
+
+;; (seq (conj numbers-in "a"))
+
+
+;; (peek numbers-in)
+;; ;;=> 1
+
+;; (seq (pop numbers-in))
+;; ;;=> (2 3 4 5)
+
+;; ;; And `empty?` can be used to check if the queue is empty.
+
+;; (empty? (drop 5 numbers-in))
+;; ;;=> false
+
+;; (empty? (queue))
+;; ;;=> true
+
+
+
+
+
+;; (use 'clojure.contrib.sql)
+
+
+;; (comment
+  
+  
+;;   (def db {:classname "com.mysql.jdbc.Driver"
+;;            :subprotocol "mysql"
+;;            :subname "//localhost:3306/clojure_test"
+;;            :user "root"
+;;            :password "root"})
+
+;;   (with-connection db
+;;     (with-query-results rs ["select *"]))
+  
+;;   )
+
+
+
+;; (def mysql-db {:dbtype "mysql"
+;;                :dbname "realparsmodel"
+;;                :user "root"
+;;                :password "password"})
+
+
+
+;; (comment
+
+;;   (queue/initialize! db-conn)
+
+
+
+;;   (sql/query mysql-db ["select *"])
+
+
+
+
+;;   (println (sql/query mysql-db
+;;                       ["select table_name from tables"])))


### PR DESCRIPTION
Added dependencies hugsql and core.async to the project.clj file

Used hugsql to create the queries.sql file in the resources folder
	queries.sql includes everything needed for setting up the table
	and any other SQL queries needed

db.clj Now holds config for the s71 database and imports the queries.sql
file into hugsql

The push method for actions.clj is currently working by adding messages
to the database and returning a list of trues and falses depending on if
the message was successfully added to the database or threw a
SQLException.  Will be branching
for the rest of actions.clj